### PR TITLE
Makes DTSTAMP optional

### DIFF
--- a/src/Rentals/Application.hs
+++ b/src/Rentals/Application.hs
@@ -62,7 +62,7 @@ appMain = do
   runStderrLoggingT . withSqlitePool "dev.sqlite3" 10 $ \pool -> liftIO $ do
     runResourceT . flip runSqlPool pool $ runMigration migrateAll
 
-    void $ forkIO $ forever $ runStderrLoggingT $ withSqlitePool "dev.sqlite3" 10 $ \pool ->
+    void $ forkIO $ forever $ runStderrLoggingT $ withSqlitePool "dev.sqlite3" 10 $ \pool -> do
       runResourceT $ flip runSqlPool pool $ do
         imports <- selectList [] []
 
@@ -100,7 +100,7 @@ appMain = do
             Left err ->
               $logError $ "Parsing ical failed: " <> T.pack err
 
-        liftIO . delay $ 60 * 60 * 1000 * 1000
+      liftIO . delay $ 60 * 60 * 1000 * 1000
 
     waiApp <- toWaiApp (App settings pool)
     run (appPort settings) $

--- a/src/Rentals/Calendar.hs
+++ b/src/Rentals/Calendar.hs
@@ -45,7 +45,7 @@ emptyVCalendar = VCalendar
 
 newVEvent :: UTCTime -> UUID -> VEvent
 newVEvent currentTime uuid = VEvent
-  { veDTStamp       = DTStamp currentTime def
+  { veDTStamp       = Just $ DTStamp currentTime def
   , veUID           = UID (LT.fromStrict . toText $ uuid) def
   , veClass         = Class Private def
   , veDTStart       = Nothing


### PR DESCRIPTION
In light of Airbnb providing broken ics files, dtstamp field for the event component was made optional. There's also a slight code re-organisation to remove the 1 hour wait before the events pulled from the sync are committed in the db transaction.