### PR TITLE
Generic env-aware error handling in Yesod errorHandler

### DIFF
--- a/src/Rentals/Foundation.hs
+++ b/src/Rentals/Foundation.hs
@@ -168,22 +168,23 @@ instance Yesod App where
 
   errorHandler errorResp = do
     env <- appEnv . appSettings <$> getYesod
-    $logInfo $ "error " <> tshow errorResp
+    $logError $ "errorHandler: " <> tshow errorResp
     let message :: Text
-        message = case errorResp of
-          NotFound -> "Not Found"
-          InternalError err -> case env of
-            EnvDev -> "Internal server error: " <> err
-            EnvProd -> "Internal server error, check the logs"
-          InvalidArgs args -> "invalid " <> tshow args
-          NotAuthenticated -> "not authenticated"
-          PermissionDenied reason -> case env of
-            EnvDev -> "permission denied " <> reason
-            EnvProd -> "permission denied "
-          BadMethod "GET" -> "bad get method"
-          BadMethod "POST" -> "bad post method"
-          BadMethod "PUT" -> "bad put method"
-          BadMethod _ -> "bad method"
+        message = case env of
+          EnvDev -> case errorResp of
+            NotFound -> "Not Found"
+            InternalError err -> "Internal server error: " <> err
+            InvalidArgs args -> "Invalid arguments: " <> tshow args
+            NotAuthenticated -> "Not authenticated"
+            PermissionDenied reason -> "Permission denied: " <> reason
+            BadMethod method -> "Bad method: " <> tshow method
+          EnvProd -> case errorResp of
+            NotFound -> "Not Found"
+            NotAuthenticated -> "Not authenticated"
+            InternalError _err -> "Something went wrong"
+            InvalidArgs _args -> "Something went wrong"
+            PermissionDenied _reason -> "Permission denied"
+            BadMethod _method -> "Something went wrong"
     selectRep $ provideRep $ defaultUserLayout $ $(whamletFile "templates/error.hamlet")
 
   makeSessionBackend _ = Just <$> defaultClientSessionBackend

--- a/src/Rentals/Handler/User/Booking.hs
+++ b/src/Rentals/Handler/User/Booking.hs
@@ -101,13 +101,13 @@ postListingBookR lid = do
               }
             }
 
-      productResponse <- runStripe conf . Stripe.postProducts
+      productResponse <- liftIO . Stripe.runWithConfiguration conf . Stripe.postProducts
         $ (Stripe.mkPostProductsRequestBody $ listingTitle listing)
           { Stripe.postProductsRequestBodyMetadata = Just $ A.fromList [("start", toJSON start), ("end", toJSON end)] }
       product' <- case responseBody productResponse of
         Stripe.PostProductsResponse200 p -> pure p
-        Stripe.PostProductsResponseDefault err -> stripeError (T.pack $ show err)
-        Stripe.PostProductsResponseError   err -> stripeError (T.pack err)
+        Stripe.PostProductsResponseDefault err -> error $ "Stripe postProducts error: " <> show err
+        Stripe.PostProductsResponseError   err -> error $ "Stripe postProducts error: " <> err
 
       let checkoutLineItem = Stripe.mkPostCheckoutSessionsRequestBodyLineItems'
             { Stripe.postCheckoutSessionsRequestBodyLineItems'Quantity = Just 1
@@ -128,11 +128,11 @@ postListingBookR lid = do
               }
             }
 
-      checkoutSessionResponse <- runStripe conf $ Stripe.postCheckoutSessions checkoutSession
+      checkoutSessionResponse <- liftIO . Stripe.runWithConfiguration conf $ Stripe.postCheckoutSessions checkoutSession
       checkout <- case responseBody checkoutSessionResponse of
         Stripe.PostCheckoutSessionsResponse200 c -> pure c
-        Stripe.PostCheckoutSessionsResponseDefault err -> stripeError (T.pack $ show err)
-        Stripe.PostCheckoutSessionsResponseError   err -> stripeError (T.pack err)
+        Stripe.PostCheckoutSessionsResponseDefault err -> error $ "Stripe postCheckoutSessions error: " <> show err
+        Stripe.PostCheckoutSessionsResponseError   err -> error $ "Stripe postCheckoutSessions error: " <> err
 
       case Stripe.checkout'sessionUrl checkout of
         Just (Stripe.NonNull url) -> redirect url
@@ -166,27 +166,27 @@ getListingBookPaymentSuccessR lid = do
               }
             }
 
-      checkoutSessionResponse <- runStripe conf . Stripe.getCheckoutSessionsSessionLineItems $
+      checkoutSessionResponse <- liftIO . Stripe.runWithConfiguration conf . Stripe.getCheckoutSessionsSessionLineItems $
         Stripe.mkGetCheckoutSessionsSessionLineItemsParameters checkoutSessionId
 
       items <- case responseBody checkoutSessionResponse of
         Stripe.GetCheckoutSessionsSessionLineItemsResponse200 items -> pure $ Stripe.getCheckoutSessionsSessionLineItemsResponseBody200Data items
-        Stripe.GetCheckoutSessionsSessionLineItemsResponseDefault err -> stripeError (T.pack $ show err)
-        Stripe.GetCheckoutSessionsSessionLineItemsResponseError   err -> stripeError (T.pack err)
+        Stripe.GetCheckoutSessionsSessionLineItemsResponseDefault err -> error $ "Stripe getCheckoutSessionsSessionLineItems error: " <> show err
+        Stripe.GetCheckoutSessionsSessionLineItemsResponseError   err -> error $ "Stripe getCheckoutSessionsSessionLineItems error: " <> err
 
       for_ items $ \i -> case Stripe.itemPrice i of
         Just (Stripe.NonNull ip) -> do
           product' <- case Stripe.itemPrice'NonNullableProduct ip of
             Just (Stripe.ItemPrice'NonNullableProduct'Text           p) -> do
-              productResponse <- runStripe conf . Stripe.getProductsId $ Stripe.mkGetProductsIdParameters p
+              productResponse <- liftIO . Stripe.runWithConfiguration conf . Stripe.getProductsId $ Stripe.mkGetProductsIdParameters p
 
               case responseBody productResponse of
                 Stripe.GetProductsIdResponse200 products -> pure $ Stripe.productMetadata products
-                Stripe.GetProductsIdResponseDefault err -> stripeError (T.pack $ show err)
-                Stripe.GetProductsIdResponseError   err -> stripeError (T.pack err)
+                Stripe.GetProductsIdResponseDefault err -> error $ "Stripe getProductsId error: " <> show err
+                Stripe.GetProductsIdResponseError   err -> error $ "Stripe getProductsId error: " <> err
 
             Just (Stripe.ItemPrice'NonNullableProduct'Product        p) -> pure $ Stripe.productMetadata p
-            Just (Stripe.ItemPrice'NonNullableProduct'DeletedProduct p) -> stripeError ("product was deleted: " <> Stripe.deletedProductId p)
+            Just (Stripe.ItemPrice'NonNullableProduct'DeletedProduct p) -> error $ "Stripe product was deleted: " <> T.unpack (Stripe.deletedProductId p)
             other -> error $ "Unxpected " <> show other
 
           let dates = map fromJSON $ A.elems product'
@@ -209,7 +209,7 @@ getListingBookPaymentSuccessR lid = do
                 flip upsert [EventBlocked =. True] $ Event lid Local uuid'
                   (succ end) (succ end) Nothing Nothing (Just "Unavailable (Local)") True False
 
-              checkoutSessionResponse' <- runStripe conf . Stripe.getCheckoutSessionsSession $
+              checkoutSessionResponse' <- liftIO . Stripe.runWithConfiguration conf . Stripe.getCheckoutSessionsSession $
                 Stripe.mkGetCheckoutSessionsSessionParameters checkoutSessionId
               case responseBody checkoutSessionResponse' of
                 Stripe.GetCheckoutSessionsSessionResponse200 checkoutSession ->
@@ -231,10 +231,10 @@ getListingBookPaymentSuccessR lid = do
                                 }
                             Nothing -> sendResponseStatus status500 $ toEncoding
                               ("An error has ocurred: no reservation found at " <> showGregorian start)
-                        _ -> stripeError "no email was provided"
-                    _ -> stripeError "no customer details provided"
-                Stripe.GetCheckoutSessionsSessionResponseDefault err -> stripeError (T.pack $ show err)
-                Stripe.GetCheckoutSessionsSessionResponseError   err -> stripeError (T.pack err)
+                        _ -> error "Stripe checkout session: no email was provided"
+                    _ -> error "Stripe checkout session: no customer details provided"
+                Stripe.GetCheckoutSessionsSessionResponseDefault err -> error $ "Stripe getCheckoutSessionsSession error: " <> show err
+                Stripe.GetCheckoutSessionsSessionResponseError   err -> error $ "Stripe getCheckoutSessionsSession error: " <> err
 
               emailBody <- defaultEmailLayout $(whamletFile "templates/email/book-alert.hamlet")
               for_ adminEmails $ \adminEmail' -> sendEmail connPool $ (emptyMail (Address Nothing appEmail'))

--- a/src/Rentals/Handler/User/Internal.hs
+++ b/src/Rentals/Handler/User/Internal.hs
@@ -3,19 +3,14 @@ module Rentals.Handler.User.Internal where
 import Yesod
 import Rentals.Foundation
 
-import           Control.Exception         (try)
 import           Data.List                 (foldl')
 import           Data.Maybe
 import           Data.Text                 (Text)
-import qualified Data.Text                 as T
 import           Data.Time.Calendar
-import           Network.HTTP.Client       (HttpException)
 import           Network.HTTP.Types.Status
 import Rentals.Database.Listing
 import Rentals.Database.Event
 import Rentals.Database.Money
-import Rentals.Settings                    (Environment(..), appEnv)
-import qualified StripeAPI                 as Stripe
 
 getQuote :: ListingId -> Day -> Day -> Handler (Money, Money)
 getQuote lid start end = runDB $ do
@@ -35,31 +30,4 @@ getQuote lid start end = runDB $ do
 
     Nothing -> sendResponseStatus status404 $ toEncoding
       ("The target listing does not exist, please check the identifier and try again" :: Text)
-
--- | Run a Stripe API call, catching HTTP-level exceptions (DNS failure,
---   timeout, connection refused) and returning an env-aware error.
-runStripe :: Stripe.Configuration -> Stripe.ClientT IO a -> Handler a
-runStripe conf action = do
-  result <- liftIO $ try (Stripe.runWithConfiguration conf action)
-  case result of
-    Right response -> pure response
-    Left httpException -> do
-      env <- appEnv . appSettings <$> getYesod
-      $logError $ "Stripe HTTP error: " <> T.pack (show (httpException :: HttpException))
-      case env of
-        EnvDev  -> sendResponseStatus status503 $ toEncoding
-          ("Payment processor connection error: " <> T.pack (show httpException))
-        EnvProd -> sendResponseStatus status503 $ toEncoding
-          ("Something went wrong" :: Text)
-
--- | Handle Stripe API-level errors with env-aware messaging.
-stripeError :: Text -> Handler a
-stripeError details = do
-  env <- appEnv . appSettings <$> getYesod
-  $logError $ "Stripe API error: " <> details
-  case env of
-    EnvDev  -> sendResponseStatus status503 $ toEncoding
-      ("Payment processor error: " <> details)
-    EnvProd -> sendResponseStatus status503 $ toEncoding
-      ("Something went wrong" :: Text)
 


### PR DESCRIPTION
## Summary
- Update `errorHandler` in Foundation.hs to mute error details in production ("Something went wrong") while showing full exception text in development
- Upgrade logging from `$logInfo` to `$logError` for all error responses
- Remove Stripe-specific `runStripe`/`stripeError` helpers — unhandled exceptions now propagate to the generic errorHandler
- Revert Booking.hs to plain `liftIO . Stripe.runWithConfiguration` with `error` for API-level failures (caught as `InternalError` by errorHandler)

This catches **any** unhandled exception from **any** handler (Stripe, SMTP, DB, etc.) in one place.

## Test plan
- [x] `cabal build` — typechecks cleanly, no warnings
- [x] `cabal test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)