### PR TITLE
Add price per extra person and max occupancy

### DIFF
--- a/migrations/down/20260408-add-guest-pricing.down.sql
+++ b/migrations/down/20260408-add-guest-pricing.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "listing" DROP COLUMN "price_per_extra_person";
+ALTER TABLE "listing" DROP COLUMN "max_people";

--- a/migrations/up/20260408-add-guest-pricing.sql
+++ b/migrations/up/20260408-add-guest-pricing.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "listing" ADD COLUMN "price_per_extra_person" INT8 NOT NULL DEFAULT 0;
+ALTER TABLE "listing" ADD COLUMN "max_people" INT8 NOT NULL DEFAULT 1;

--- a/rentals.cabal
+++ b/rentals.cabal
@@ -199,6 +199,7 @@ test-suite rentals-test
     BookingSpec
     EmailSpec
     UnavailableDatesSpec
+    GuestPricingSpec
 
   ghc-options:
     -Wno-unused-packages

--- a/src/Rentals/Database/Listing.hs
+++ b/src/Rentals/Database/Listing.hs
@@ -66,6 +66,8 @@ Listing json
   address          Text  default=''
   handlerName      Text  default=''
   handlerPhone     Text  default=''
+  pricePerExtraPerson Money default=0
+  maxPeople        Int   default=1
 
   slug             Slug
   uuid             UUID

--- a/src/Rentals/Database/Money.hs
+++ b/src/Rentals/Database/Money.hs
@@ -10,7 +10,7 @@ import Text.Blaze(ToMarkup(..))
 import Rentals.Tshow (tshow)
 
 newtype Money = Money { unMoney :: Centi }
-  deriving (Eq, Ord, Num, Fractional)
+  deriving (Eq, Ord, Num, Fractional, Show)
 $(deriveJSON (defaultOptions {unwrapUnaryRecords = True}) ''Money)
 
 instance PersistField Money where

--- a/src/Rentals/Handler/Admin/Listing.hs
+++ b/src/Rentals/Handler/Admin/Listing.hs
@@ -48,15 +48,17 @@ putAdminListingR lid = do
       let slug = Slug . slugify $ listingNewTitle listing
 
       runDB . replace lid $ original
-        { listingTitle            = listingNewTitle listing
-        , listingDescription      = listingNewDescription listing
-        , listingPrice            = listingNewPrice listing
-        , listingCleaning         = listingNewCleaning listing
-        , listingCountry          = listingNewCountry listing
-        , listingAddress          = listingNewAddress listing
-        , listingHandlerName      = listingNewHandlerName listing
-        , listingHandlerPhone     = listingNewHandlerPhone listing
-        , listingSlug             = slug
+        { listingTitle               = listingNewTitle listing
+        , listingDescription         = listingNewDescription listing
+        , listingPrice               = listingNewPrice listing
+        , listingCleaning            = listingNewCleaning listing
+        , listingCountry             = listingNewCountry listing
+        , listingAddress             = listingNewAddress listing
+        , listingHandlerName         = listingNewHandlerName listing
+        , listingHandlerPhone        = listingNewHandlerPhone listing
+        , listingPricePerExtraPerson = listingNewPricePerExtraPerson listing
+        , listingMaxPeople           = listingNewMaxPeople listing
+        , listingSlug                = slug
         }
 
       sendResponseStatus status200 $ toEncoding slug
@@ -131,16 +133,18 @@ putAdminListingNewR = do
     let slug = Slug . slugify $ listingNewTitle listing
 
     mlid <- insertUnique $ Listing {
-          listingTitle            =     (listingNewTitle listing)
+          listingTitle               =     (listingNewTitle listing)
         , listingCurrency = UsDollar
-        , listingDescription      =     (listingNewDescription listing)
-        , listingPrice            =     (listingNewPrice listing)
-        , listingCleaning         =     (listingNewCleaning listing)
-        , listingCountry          =     (listingNewCountry listing)
-        , listingAddress          =     (listingNewAddress listing)
-        , listingHandlerName      =     (listingNewHandlerName listing)
-        , listingHandlerPhone     =     (listingNewHandlerPhone listing)
-        , listingSlug             =     slug
+        , listingDescription         =     (listingNewDescription listing)
+        , listingPrice               =     (listingNewPrice listing)
+        , listingCleaning            =     (listingNewCleaning listing)
+        , listingCountry             =     (listingNewCountry listing)
+        , listingAddress             =     (listingNewAddress listing)
+        , listingHandlerName         =     (listingNewHandlerName listing)
+        , listingHandlerPhone        =     (listingNewHandlerPhone listing)
+        , listingPricePerExtraPerson =     (listingNewPricePerExtraPerson listing)
+        , listingMaxPeople           =     (listingNewMaxPeople listing)
+        , listingSlug                =     slug
         , listingUuid = uuid
         }
 

--- a/src/Rentals/Handler/User/Booking.hs
+++ b/src/Rentals/Handler/User/Booking.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Rentals.Handler.User.Booking where
 
 import Yesod
@@ -16,7 +17,9 @@ import Rentals.Database.Checkout
 import Rentals.Database.Money
 import           Control.Monad
 import           Data.Aeson                                  (Result(..), fromJSON)
+import qualified Data.Aeson.Key                              as AK
 import qualified Data.Aeson.KeyMap                           as A
+import           Data.Maybe                                  (fromMaybe)
 import           Data.Text                                   (Text)
 import qualified Data.Text                                   as T
 import           Data.Time.Calendar
@@ -35,8 +38,9 @@ import Rentals.Currency (toStripe, printCurrency)
 import Rentals.Widget
 
 data BookListForm = BookListForm {
-    startDate :: Day
-  , endDate :: Day
+    startDate  :: Day
+  , endDate    :: Day
+  , guestCount :: Int
  }
 
 type Form a = Markup -> MForm Handler (FormResult a, Widget)
@@ -45,10 +49,11 @@ boookListForm :: Form BookListForm
 boookListForm csrf = do
   (startRes, startView) <- mreq dayField "start date" Nothing
   (endRes, endView) <- mreq dayField "end date" Nothing
+  (guestRes, guestView) <- mreq intField "Number of guests" (Just 1)
 
   let view = $(widgetFile "listing/bookform")
 
-      result = BookListForm <$> startRes <*> endRes
+      result = BookListForm <$> startRes <*> endRes <*> guestRes
   pure (result, view)
 
 
@@ -90,6 +95,8 @@ getListingBookR lid = do
   listing <- runDB $ get404 lid
   (form, enc) <- generateFormPost boookListForm
   mmsg <- getMessage
+  let hasExtraPersonPrice = listingPricePerExtraPerson listing > Money 0
+      hasMultipleGuests   = listingMaxPeople listing > 1
 
   userLayoutNoJs $(widgetFile "listing/book")
 
@@ -98,13 +105,23 @@ postListingBookR lid = do
   ((formResult, _form), _enc) <- runFormPost boookListForm
 
   case formResult of
-    FormSuccess (BookListForm start end) -> do
+    FormSuccess (BookListForm start end guests) -> do
       when (start >= end) $ do
         setMessage "Start date must be before end date."
         redirect (ListingBookR lid)
 
       when (length [start .. end] < 3) $ do
         setMessage "The minimum booking duration is 3 days."
+        redirect (ListingBookR lid)
+
+      listing <- runDB $ get404 lid
+
+      when (guests < 1) $ do
+        setMessage "Number of guests must be at least 1."
+        redirect (ListingBookR lid)
+
+      when (guests > listingMaxPeople listing) $ do
+        setMessage $ toHtml $ ("The maximum number of guests is " <> T.pack (show (listingMaxPeople listing)) <> "." :: Text)
         redirect (ListingBookR lid)
 
       conflicts <- runDB $ selectList
@@ -135,8 +152,7 @@ postListingBookR lid = do
           ("Some of your selected dates are already booked." <> suggestions :: Text)
         redirect (ListingBookR lid)
 
-      listing <- runDB $ get404 lid
-      (quote, cleaningFee) <- getQuote lid start end
+      (quote, cleaningFee) <- getQuote lid start end guests
       stripeKeys <- getsYesod $ appStripe . appSettings
       render     <- getUrlRender
       let amount = 100 * ((floor . unMoney $ quote) + (floor . unMoney $ cleaningFee))
@@ -150,7 +166,7 @@ postListingBookR lid = do
 
       productResponse <- liftIO . Stripe.runWithConfiguration conf . Stripe.postProducts
         $ (Stripe.mkPostProductsRequestBody $ listingTitle listing)
-          { Stripe.postProductsRequestBodyMetadata = Just $ A.fromList [("start", toJSON start), ("end", toJSON end)] }
+          { Stripe.postProductsRequestBodyMetadata = Just $ A.fromList [("start", toJSON start), ("end", toJSON end), ("guests", toJSON guests)] }
       product' <- case responseBody productResponse of
         Stripe.PostProductsResponse200 p -> pure p
         Stripe.PostProductsResponseDefault err -> error $ "Stripe postProducts error: " <> show err
@@ -236,10 +252,17 @@ getListingBookPaymentSuccessR lid = do
             Just (Stripe.ItemPrice'NonNullableProduct'DeletedProduct p) -> error $ "Stripe product was deleted: " <> T.unpack (Stripe.deletedProductId p)
             other -> error $ "Unxpected " <> show other
 
-          let dates = map fromJSON $ A.elems product'
-          case dates of
-            [] -> error "Empty dates"
-            [Success start', Success end'] -> do
+          let fromMeta :: FromJSON a => AK.Key -> Maybe a
+              fromMeta key = A.lookup key product' >>= \v -> case fromJSON v of
+                Success d -> Just d
+                _         -> Nothing
+              mstart = fromMeta "start" :: Maybe Day
+              mend   = fromMeta "end"   :: Maybe Day
+              guests = fromMaybe 1 (fromMeta "guests" :: Maybe Int)
+          case (mstart, mend) of
+            (Nothing, _) -> error "Missing start date in metadata"
+            (_, Nothing) -> error "Missing end date in metadata"
+            (Just start', Just end') -> do
               let (start, end) = if start' > end' then (end', start') else (start', end')
 
               for_ [start .. end] $ \d -> do
@@ -289,7 +312,6 @@ getListingBookPaymentSuccessR lid = do
                 , mailHeaders = [("Subject", "New booking - " <> listingTitle listing)]
                 , mailParts   = [[htmlPart $ renderHtml emailBody]]
                 }
-            other -> error $ "Unxpected" <> show other
         other -> error $ "Unxpected" <> show other
 
 

--- a/src/Rentals/Handler/User/Internal.hs
+++ b/src/Rentals/Handler/User/Internal.hs
@@ -1,4 +1,7 @@
-module Rentals.Handler.User.Internal where
+module Rentals.Handler.User.Internal
+  ( getQuote
+  , calculateNightlyCharge
+  ) where
 
 import Yesod
 import Rentals.Foundation
@@ -12,22 +15,40 @@ import Rentals.Database.Listing
 import Rentals.Database.Event
 import Rentals.Database.Money
 
-getQuote :: ListingId -> Day -> Day -> Handler (Money, Money)
-getQuote lid start end = runDB $ do
+-- | Pure pricing calculation.
+--   Extra-person surcharge applies uniformly to all nights
+--   (both standard-priced and override-priced).
+calculateNightlyCharge :: Money -> [Money] -> Money -> Int -> Int -> Money
+calculateNightlyCharge basePrice overridePrices pricePerExtraPerson totalNights guestCount =
+  let standardDays = totalNights - length overridePrices
+      baseCharge   = basePrice * (Money $ realToFrac standardDays) + foldl' (+) 0 overridePrices
+      extraPersons = max 0 (guestCount - 1)
+      extraCharge  = pricePerExtraPerson
+                   * (Money $ realToFrac extraPersons)
+                   * (Money $ realToFrac totalNights)
+  in baseCharge + extraCharge
+
+getQuote :: ListingId -> Day -> Day -> Int -> Handler (Money, Money)
+getQuote lid start end guestCount = runDB $ do
   mlisting <- get lid
 
   case mlisting of
     Just listing -> do
-      prices <- catMaybes . map (eventPrice . entityVal) <$> selectList
+      overridePrices <- catMaybes . map (eventPrice . entityVal) <$> selectList
         [ EventListing ==. lid
         , EventStart >=. start
         , EventStart <=. end
         , EventPrice !=. Nothing
         ] []
 
-      let days = length [start .. end] - length prices
-      pure $ ((listingPrice listing) * (Money $ realToFrac days) + foldl' (+) 0 prices, listingCleaning listing)
+      let totalNights = length [start .. end]
+          nightlyCharge = calculateNightlyCharge
+            (listingPrice listing)
+            overridePrices
+            (listingPricePerExtraPerson listing)
+            totalNights
+            guestCount
+      pure (nightlyCharge, listingCleaning listing)
 
     Nothing -> sendResponseStatus status404 $ toEncoding
       ("The target listing does not exist, please check the identifier and try again" :: Text)
-

--- a/src/Rentals/Handler/View/Listings.hs
+++ b/src/Rentals/Handler/View/Listings.hs
@@ -6,6 +6,7 @@ import Yesod
 import Rentals.Database.Listing
 import Rentals.Database.ListingImage
 import Rentals.Database.Event
+import Rentals.Database.Money
 
 import           Data.Traversable
 
@@ -38,5 +39,7 @@ getViewListingR lid _slug = do
       ( listing
       , map (listingImageUuid . entityVal) images
       )
+  let hasExtraPersonPrice = listingPricePerExtraPerson listing > Money 0
+      hasMultipleGuests   = listingMaxPeople listing > 1
 
   defaultUserLayout $(whamletFile "templates/user/listing.hamlet")

--- a/src/Rentals/JSON.hs
+++ b/src/Rentals/JSON.hs
@@ -18,13 +18,15 @@ parseJsonBody' = do
       ("Unable to parse the request body: " <> err)
 
 data ListingNew = ListingNew
-  { listingNewTitle        :: Text
-  , listingNewDescription  :: Text
-  , listingNewPrice        :: Money
-  , listingNewCleaning     :: Money
-  , listingNewCountry      :: Text
-  , listingNewAddress      :: Text
-  , listingNewHandlerName  :: Text
-  , listingNewHandlerPhone :: Text
+  { listingNewTitle               :: Text
+  , listingNewDescription         :: Text
+  , listingNewPrice               :: Money
+  , listingNewCleaning            :: Money
+  , listingNewCountry             :: Text
+  , listingNewAddress             :: Text
+  , listingNewHandlerName         :: Text
+  , listingNewHandlerPhone        :: Text
+  , listingNewPricePerExtraPerson :: Money
+  , listingNewMaxPeople           :: Int
   }
 $(deriveJSON (defaultOptions {unwrapUnaryRecords = True}) ''ListingNew)

--- a/templates/admin/admin.hamlet
+++ b/templates/admin/admin.hamlet
@@ -47,6 +47,16 @@
                 <div class="form-floating">
                   <input name="cleaning" type="number" step="1" class="form-control" placeholder="cleaning fee">
                   <label>cleaning fee
+            <div class="col-9 mb-3">
+              <div class="input-group">
+                <span class="input-group-text">
+                  <i class="bi bi-people-fill">
+                <div class="form-floating">
+                  <input name="maxPeople" type="number" step="1" min="1" class="form-control" placeholder="max guests" value="1">
+                  <label>max guests
+                <div class="form-floating">
+                  <input name="pricePerExtraPerson" type="number" step="1" class="form-control" placeholder="extra person price" value="0">
+                  <label>extra person price
             <div class="d-grid col-3 mb-3">
               <button class="btn btn-primary">
                 <i class="bi bi-floppy">

--- a/templates/admin/listing.hamlet
+++ b/templates/admin/listing.hamlet
@@ -47,6 +47,16 @@
                 <div class="form-floating">
                   <input name="cleaning" type="number" step="1" class="form-control" value=#{listingCleaning l} placeholder="cleaning fee">
                   <label>cleaning fee
+            <div class="col-9 mb-3">
+              <div class="input-group">
+                <span class="input-group-text">
+                  <i class="bi bi-people-fill">
+                <div class="form-floating">
+                  <input name="maxPeople" type="number" step="1" min="1" class="form-control" value=#{listingMaxPeople l} placeholder="max guests">
+                  <label>max guests
+                <div class="form-floating">
+                  <input name="pricePerExtraPerson" type="number" step="1" class="form-control" value=#{listingPricePerExtraPerson l} placeholder="extra person price">
+                  <label>extra person price
             <div class="d-grid col-3 mb-3">
               <button class="btn btn-primary">
                 <i class="bi bi-floppy">

--- a/templates/email/book-alert.hamlet
+++ b/templates/email/book-alert.hamlet
@@ -1,2 +1,2 @@
 <p>New booking for #{listingTitle listing}.
-<p>from #{start} to #{end}
+<p>from #{start} to #{end} for #{show guests} guest(s).

--- a/templates/email/book-confirm.hamlet
+++ b/templates/email/book-confirm.hamlet
@@ -1,6 +1,6 @@
 
 <p>Thank you for your booking on #{listingTitle listing}.
-The dates we received is from #{start} to #{end}
+The dates we received is from #{start} to #{end} for #{show guests} guest(s).
 
 <p>For any comments or questions you can contact the property manager #{listingHandlerName listing} on #{listingHandlerPhone listing}.
 

--- a/templates/listing/book.hamlet
+++ b/templates/listing/book.hamlet
@@ -15,6 +15,11 @@ $maybe msg <- mmsg
               <div class="fs-7 text-secondary">per night
               <div class="fs-6 mt-1">^{printCurrency (listingCurrency listing)} #{listingCleaning listing}
               <div class="fs-7 text-secondary">cleaning fee
+              $if hasExtraPersonPrice
+                <div class="fs-6 mt-1">^{printCurrency (listingCurrency listing)} #{listingPricePerExtraPerson listing}
+                <div class="fs-7 text-secondary">per extra person per night
+              $if hasMultipleGuests
+                <div class="fs-7 mt-1 text-secondary">max #{listingMaxPeople listing} guests
             <hr>
             <form method=post action=@{ListingBookR lid} enctype=#{enc}>
               ^{form}

--- a/templates/listing/bookform.hamlet
+++ b/templates/listing/bookform.hamlet
@@ -5,5 +5,8 @@
 <div class="mb-2">
   <label class="form-label" for=#{fvId endView}>End date
   ^{fvInput endView}
+<div class="mb-2">
+  <label class="form-label" for=#{fvId guestView}>Number of guests
+  ^{fvInput guestView}
 <div class="d-grid mt-3">
   <button type=submit class="btn btn-primary">Book now

--- a/templates/script/admin/forms.julius
+++ b/templates/script/admin/forms.julius
@@ -106,14 +106,16 @@ window.addEventListener("load", function() {
       req.setRequestHeader("Accept", "application/json");
 
       req.send(JSON.stringify({
-        "listingNewTitle"       : newListingForm.elements.title.value,
-        "listingNewDescription" : newListingForm.elements.description.value,
-        "listingNewPrice"       : Number(newListingForm.elements.price.value),
-        "listingNewCleaning"    : Number(newListingForm.elements.cleaning.value),
-        "listingNewHandlerName" : newListingForm.elements.handlerName.value,
-        "listingNewHandlerPhone": newListingForm.elements.handlerPhone.value,
-        "listingNewCountry"     : newListingForm.elements.country.value,
-        "listingNewAddress"     : newListingForm.elements.address.value
+        "listingNewTitle"               : newListingForm.elements.title.value,
+        "listingNewDescription"         : newListingForm.elements.description.value,
+        "listingNewPrice"               : Number(newListingForm.elements.price.value),
+        "listingNewCleaning"            : Number(newListingForm.elements.cleaning.value),
+        "listingNewHandlerName"         : newListingForm.elements.handlerName.value,
+        "listingNewHandlerPhone"        : newListingForm.elements.handlerPhone.value,
+        "listingNewCountry"             : newListingForm.elements.country.value,
+        "listingNewAddress"             : newListingForm.elements.address.value,
+        "listingNewPricePerExtraPerson" : Number(newListingForm.elements.pricePerExtraPerson.value),
+        "listingNewMaxPeople"           : Number(newListingForm.elements.maxPeople.value)
       }));
 
       return false;
@@ -136,14 +138,16 @@ window.addEventListener("load", function() {
       req.setRequestHeader("Accept", "application/json");
 
       req.send(JSON.stringify({
-        "listingNewTitle"       : editListingForm.elements.title.value,
-        "listingNewDescription" : editListingForm.elements.description.value,
-        "listingNewPrice"       : Number(editListingForm.elements.price.value),
-        "listingNewCleaning"    : Number(editListingForm.elements.cleaning.value),
-        "listingNewHandlerName" : editListingForm.elements.handlerName.value,
-        "listingNewHandlerPhone": editListingForm.elements.handlerPhone.value,
-        "listingNewCountry"     : editListingForm.elements.country.value,
-        "listingNewAddress"     : editListingForm.elements.address.value
+        "listingNewTitle"               : editListingForm.elements.title.value,
+        "listingNewDescription"         : editListingForm.elements.description.value,
+        "listingNewPrice"               : Number(editListingForm.elements.price.value),
+        "listingNewCleaning"            : Number(editListingForm.elements.cleaning.value),
+        "listingNewHandlerName"         : editListingForm.elements.handlerName.value,
+        "listingNewHandlerPhone"        : editListingForm.elements.handlerPhone.value,
+        "listingNewCountry"             : editListingForm.elements.country.value,
+        "listingNewAddress"             : editListingForm.elements.address.value,
+        "listingNewPricePerExtraPerson" : Number(editListingForm.elements.pricePerExtraPerson.value),
+        "listingNewMaxPeople"           : Number(editListingForm.elements.maxPeople.value)
       }));
 
       return false;

--- a/templates/user/listing.hamlet
+++ b/templates/user/listing.hamlet
@@ -28,5 +28,10 @@
                   <div class="fs-7 lh-1 text-end text-secondary">per night
                   <div class="fs-6 text-end mt-2">^{printCurrency (listingCurrency listing)} #{listingCleaning listing}
                   <div class="fs-7 lh-1 text-end text-secondary">cleaning fee
+                  $if hasExtraPersonPrice
+                    <div class="fs-6 text-end mt-2">^{printCurrency (listingCurrency listing)} #{listingPricePerExtraPerson listing}
+                    <div class="fs-7 lh-1 text-end text-secondary">per extra person per night
+                  $if hasMultipleGuests
+                    <div class="fs-7 mt-1 text-end text-secondary">max #{listingMaxPeople listing} guests
                 <div class="d-grid mt-3">
                   <a href=@{ListingBookR lid} class="btn btn-primary">Book now

--- a/test/BookingSpec.hs
+++ b/test/BookingSpec.hs
@@ -2,7 +2,7 @@
 
 module BookingSpec (bookingSpec) where
 
-import Test.Hspec (Spec, runIO)
+import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 import Yesod.Test
 import Database.Persist (insert)
 import Database.Persist.Sql (runSqlPool, toSqlKey)
@@ -12,6 +12,7 @@ import Rentals.Foundation
 import Rentals.Application ()  -- YesodDispatch instance
 import Rentals.Database.Listing
 import Rentals.Database.Money
+import Rentals.Handler.User.Internal (calculateNightlyCharge)
 import Rentals.Currency
 
 import Data.UUID (UUID, fromString)
@@ -35,6 +36,8 @@ testListing = Listing
   , listingAddress = "123 Test St"
   , listingHandlerName = "Test Handler"
   , listingHandlerPhone = "555-1234"
+  , listingPricePerExtraPerson = Money 0
+  , listingMaxPeople = 4
   , listingSlug = testSlug
   , listingUuid = testUUID
   }
@@ -78,6 +81,7 @@ bookingSpec = do
           addToken
           byLabelExact "Start date" "2025-01-10"
           byLabelExact "End date" "2025-01-05"
+          byLabelExact "Number of guests" "1"
         statusIs 303
 
       yit "redirects with error when booking is less than 3 days" $ do
@@ -88,6 +92,7 @@ bookingSpec = do
           addToken
           byLabelExact "Start date" "2025-01-01"
           byLabelExact "End date" "2025-01-02"
+          byLabelExact "Number of guests" "1"
         statusIs 303
 
     ydescribe "Cancel handler" $ do
@@ -96,9 +101,51 @@ bookingSpec = do
         get $ ListingBookPaymentCancelR lid
         statusIs 303
 
+    ydescribe "Guest count validation" $ do
+
+      yit "redirects when guest count exceeds max people" $ do
+        get $ ListingBookR lid
+        request $ do
+          setMethod "POST"
+          setUrl $ ListingBookR lid
+          addToken
+          byLabelExact "Start date" "2025-06-01"
+          byLabelExact "End date" "2025-06-05"
+          byLabelExact "Number of guests" "5"
+        statusIs 303
+
+      yit "redirects when guest count is zero" $ do
+        get $ ListingBookR lid
+        request $ do
+          setMethod "POST"
+          setUrl $ ListingBookR lid
+          addToken
+          byLabelExact "Start date" "2025-06-01"
+          byLabelExact "End date" "2025-06-05"
+          byLabelExact "Number of guests" "0"
+        statusIs 303
+
     ydescribe "Listing view page" $ do
 
       yit "has a Book Now link to the booking page" $ do
         get $ ViewListingR lid testSlug
         statusIs 200
         htmlAnyContain "a" "Book now"
+
+  describe "calculateNightlyCharge" $ do
+
+    it "charges base price only for a single guest" $ do
+      calculateNightlyCharge (Money 100) [] (Money 10) 5 1
+        `shouldBe` Money 500
+
+    it "adds extra person surcharge for multiple guests" $ do
+      calculateNightlyCharge (Money 100) [] (Money 10) 5 3
+        `shouldBe` Money 600
+
+    it "combines override prices with extra person surcharge" $ do
+      calculateNightlyCharge (Money 100) [Money 80, Money 90] (Money 10) 5 2
+        `shouldBe` Money 520
+
+    it "charges no surcharge when pricePerExtraPerson is zero" $ do
+      calculateNightlyCharge (Money 100) [] (Money 0) 5 4
+        `shouldBe` Money 500

--- a/test/EmailSpec.hs
+++ b/test/EmailSpec.hs
@@ -41,6 +41,8 @@ testListing = Listing
   , listingAddress = "456 Email St"
   , listingHandlerName = "Email Handler"
   , listingHandlerPhone = "555-5678"
+  , listingPricePerExtraPerson = Money 0
+  , listingMaxPeople = 4
   , listingSlug = testSlug
   , listingUuid = testUUID
   }

--- a/test/GuestPricingSpec.hs
+++ b/test/GuestPricingSpec.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GuestPricingSpec (guestPricingSpec) where
+
+import Test.Hspec (Spec, runIO)
+import Yesod.Test
+import Yesod.Auth (Route(..))
+import Database.Persist (insert)
+import Database.Persist.Sql (runSqlPool)
+import Control.Monad.Logger (runNoLoggingT)
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (encode, object, (.=))
+
+import Rentals.Foundation
+import Rentals.Application ()  -- YesodDispatch instance
+import Rentals.Database.Listing
+import Rentals.Database.Money
+import Rentals.Currency
+
+import Data.Text (pack)
+import Data.Time.Calendar (addDays)
+import Data.Time.Clock (getCurrentTime, utctDay)
+import Data.UUID (UUID, fromString)
+import Data.Maybe (fromJust)
+import TestFoundation
+
+testUUID :: UUID
+testUUID = fromJust $ fromString "99887766-5544-3322-1100-aabbccddeeff"
+
+testSlug :: Slug
+testSlug = Slug "guest-pricing-test"
+
+testListing :: Listing
+testListing = Listing
+  { listingTitle = "Guest Pricing Test"
+  , listingDescription = "A listing for guest pricing integration test"
+  , listingPrice = Money 100
+  , listingCurrency = UsDollar
+  , listingCleaning = Money 25
+  , listingCountry = "US"
+  , listingAddress = "101 Guest St"
+  , listingHandlerName = "Test Handler"
+  , listingHandlerPhone = "555-9999"
+  , listingPricePerExtraPerson = Money 10
+  , listingMaxPeople = 4
+  , listingSlug = testSlug
+  , listingUuid = testUUID
+  }
+
+seedListing :: App -> IO ListingId
+seedListing app =
+  runNoLoggingT $ runSqlPool (insert testListing) (appConnPool app)
+
+loginAdmin :: YesodExample App ()
+loginAdmin = do
+  request $ do
+    setMethod "POST"
+    setUrl $ AuthR $ PluginR "hardcoded" ["login"]
+    addPostParam "username" "admin"
+    addPostParam "password" "admin"
+
+guestPricingSpec :: Spec
+guestPricingSpec = do
+  app <- runIO makeTestApp
+  lid <- runIO $ seedListing app
+
+  yesodSpec app $ do
+    ydescribe "Booking page displays extra person pricing" $ do
+
+      yit "shows extra person price and max guests" $ do
+        get $ ListingBookR lid
+        statusIs 200
+        htmlAnyContain "div" "per extra person per night"
+        htmlAnyContain "div" "max 4 guests"
+
+    ydescribe "Listing detail page shows extra person pricing" $ do
+
+      yit "shows extra person price and max guests" $ do
+        get $ ViewListingR lid testSlug
+        statusIs 200
+        htmlAnyContain "div" "per extra person per night"
+        htmlAnyContain "div" "max 4 guests"
+
+    ydescribe "Booking with guest counts" $ do
+
+      yit "accepts booking with multiple guests within limit" $ do
+        today <- liftIO $ utctDay <$> getCurrentTime
+        let bookStart = addDays 50 today
+            bookEnd   = addDays 55 today
+        get $ ListingBookR lid
+        request $ do
+          setMethod "POST"
+          setUrl $ ListingBookR lid
+          addToken
+          byLabelExact "Start date" (pack $ show bookStart)
+          byLabelExact "End date" (pack $ show bookEnd)
+          byLabelExact "Number of guests" "3"
+        -- Stripe API call fails in test env, but validation passed
+        statusIs 500
+
+      yit "accepts booking at exactly max guests" $ do
+        today <- liftIO $ utctDay <$> getCurrentTime
+        let bookStart = addDays 60 today
+            bookEnd   = addDays 65 today
+        get $ ListingBookR lid
+        request $ do
+          setMethod "POST"
+          setUrl $ ListingBookR lid
+          addToken
+          byLabelExact "Start date" (pack $ show bookStart)
+          byLabelExact "End date" (pack $ show bookEnd)
+          byLabelExact "Number of guests" "4"
+        -- Stripe API call fails in test env, but validation passed
+        statusIs 500
+
+      yit "rejects booking when guests exceed max" $ do
+        today <- liftIO $ utctDay <$> getCurrentTime
+        let bookStart = addDays 70 today
+            bookEnd   = addDays 75 today
+        get $ ListingBookR lid
+        request $ do
+          setMethod "POST"
+          setUrl $ ListingBookR lid
+          addToken
+          byLabelExact "Start date" (pack $ show bookStart)
+          byLabelExact "End date" (pack $ show bookEnd)
+          byLabelExact "Number of guests" "5"
+        statusIs 303
+        get $ ListingBookR lid
+        statusIs 200
+        htmlAnyContain "div" "maximum"
+
+      yit "accepts booking with 1 guest (backward compat)" $ do
+        today <- liftIO $ utctDay <$> getCurrentTime
+        let bookStart = addDays 80 today
+            bookEnd   = addDays 85 today
+        get $ ListingBookR lid
+        request $ do
+          setMethod "POST"
+          setUrl $ ListingBookR lid
+          addToken
+          byLabelExact "Start date" (pack $ show bookStart)
+          byLabelExact "End date" (pack $ show bookEnd)
+          byLabelExact "Number of guests" "1"
+        -- Stripe API call fails in test env, but validation passed
+        statusIs 500
+
+    ydescribe "Booking page form" $ do
+
+      yit "shows the guest count field" $ do
+        get $ ListingBookR lid
+        statusIs 200
+        htmlAnyContain "label" "Number of guests"
+
+    ydescribe "Admin guest pricing CRUD" $ do
+
+      yit "creates listing with guest pricing fields" $ do
+        loginAdmin
+        request $ do
+          setMethod "PUT"
+          setUrl AdminListingNewR
+          addRequestHeader ("Content-Type", "application/json")
+          setRequestBody $ encode $ object
+            [ "listingNewTitle"               .= ("Admin GP Test" :: String)
+            , "listingNewDescription"         .= ("desc" :: String)
+            , "listingNewPrice"               .= (50 :: Int)
+            , "listingNewCleaning"            .= (10 :: Int)
+            , "listingNewCountry"             .= ("US" :: String)
+            , "listingNewAddress"             .= ("1 St" :: String)
+            , "listingNewHandlerName"         .= ("Handler" :: String)
+            , "listingNewHandlerPhone"        .= ("555" :: String)
+            , "listingNewPricePerExtraPerson" .= (15 :: Int)
+            , "listingNewMaxPeople"           .= (6 :: Int)
+            ]
+        statusIs 201
+
+      yit "updates listing guest pricing fields" $ do
+        loginAdmin
+        request $ do
+          setMethod "PUT"
+          setUrl $ AdminListingR lid
+          addRequestHeader ("Content-Type", "application/json")
+          setRequestBody $ encode $ object
+            [ "listingNewTitle"               .= ("Guest Pricing Test" :: String)
+            , "listingNewDescription"         .= ("A listing for guest pricing integration test" :: String)
+            , "listingNewPrice"               .= (100 :: Int)
+            , "listingNewCleaning"            .= (25 :: Int)
+            , "listingNewCountry"             .= ("US" :: String)
+            , "listingNewAddress"             .= ("101 Guest St" :: String)
+            , "listingNewHandlerName"         .= ("Test Handler" :: String)
+            , "listingNewHandlerPhone"        .= ("555-9999" :: String)
+            , "listingNewPricePerExtraPerson" .= (20 :: Int)
+            , "listingNewMaxPeople"           .= (8 :: Int)
+            ]
+        statusIs 200

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,9 +4,11 @@ import Test.Hspec
 import BookingSpec (bookingSpec)
 import EmailSpec (emailSpec)
 import UnavailableDatesSpec (unavailableDatesSpec)
+import GuestPricingSpec (guestPricingSpec)
 
 main :: IO ()
 main = hspec $ do
   bookingSpec
   emailSpec
   unavailableDatesSpec
+  guestPricingSpec

--- a/test/UnavailableDatesSpec.hs
+++ b/test/UnavailableDatesSpec.hs
@@ -41,6 +41,8 @@ testListing = Listing
   , listingAddress = "789 Past St"
   , listingHandlerName = "Test Handler"
   , listingHandlerPhone = "555-0000"
+  , listingPricePerExtraPerson = Money 0
+  , listingMaxPeople = 4
   , listingSlug = testSlug
   , listingUuid = testUUID
   }
@@ -97,6 +99,7 @@ unavailableDatesSpec = do
           addToken
           byLabelExact "Start date" (pack $ show bookStart)
           byLabelExact "End date" (pack $ show bookEnd)
+          byLabelExact "Number of guests" "1"
         statusIs 303
         -- Follow the redirect to see the flash message
         get $ ListingBookR lid
@@ -122,6 +125,7 @@ unavailableDatesSpec = do
           addToken
           byLabelExact "Start date" (pack $ show bookStart)
           byLabelExact "End date" (pack $ show bookEnd)
+          byLabelExact "Number of guests" "1"
         -- Stripe API call fails in test env, but validation passed
         statusIs 500
 


### PR DESCRIPTION
## Summary
- Add `pricePerExtraPerson` and `maxPeople` fields to listings (schema + migrations)
- Extend booking form with guest count field; validate guests within 1..maxPeople
- Extract pure `calculateNightlyCharge` for testability; surcharge applies uniformly to all nights
- Wire new fields through admin create/update (JSON, handlers, templates, JS payloads)
- Display extra-person pricing conditionally on booking and listing detail pages
- Include guest count in Stripe product metadata and email templates
- Parse metadata by key name instead of positional `A.elems` in success handler

## Test plan
- [x] 4 unit tests for `calculateNightlyCharge` pricing arithmetic
- [x] 2 guest validation tests (exceeds max → 303, zero guests → 303)
- [x] 9 integration tests in `GuestPricingSpec` (page rendering, form submission with various guest counts, admin CRUD)
- [x] All existing tests updated with new fixture fields and guest count form param
- [x] 26 tests pass, 0 failures
- [x] New tests verified to fail on master (compile errors for missing fields/exports)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)